### PR TITLE
fix:reviewのcreated_atの型をtimestampに統一

### DIFF
--- a/funcs/review_sort.py
+++ b/funcs/review_sort.py
@@ -6,8 +6,8 @@ def review_sort(sort_option, reviews):
     elif sort_option == 'evaluation_asc':
         return sorted(reviews, key=lambda r: r.to_dict()['evaluation'])
     elif sort_option == 'newest':
-        return sorted(reviews, key=lambda r: datetime.strptime(r.to_dict()['created_at'], "%Y-%m-%d %H:%M:%S"), reverse=True)
+        return sorted(reviews, key=lambda r: r.to_dict()['created_at'], reverse=True)
     elif sort_option == 'oldest':
-        return sorted(reviews, key=lambda r: datetime.strptime(r.to_dict()['created_at'], "%Y-%m-%d %H:%M:%S"))
+        return sorted(reviews, key=lambda r: r.to_dict()['created_at'])
     else:
         return reviews

--- a/pages/reviewAdd.py
+++ b/pages/reviewAdd.py
@@ -4,6 +4,7 @@ from funcs.wiki import get_manga_title,get_wikipedia_page_details
 from firebase_admin import credentials, firestore
 from datetime import datetime
 from funcs.review_sort import review_sort
+import time
 
 reviewAdd_bp = Blueprint('reviewAdd', __name__)
 user_doc_ref = db.collection('user')
@@ -46,7 +47,7 @@ def review():
         review_format["mangaTitle"]=manga_title
         review_format["contents"]=comment
         review_format["user_id"]=user_id
-        review_format["created_at"]= datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        review_format["created_at"]= time.mktime(datetime.now())
         review_document=review_doc_ref.document() 
         review_document.set(review_format)
         review_document_id = review_document.id


### PR DESCRIPTION
# 行ったこと
created_atがtimestampに変わっていたため対応
# なぜ変更したか
- レビューを日付でソートするとエラーが出るため
# 変更点
- 格納の型をstrからtimestampへ変更
- ソートのラムダ式も型変換処理をスキップ